### PR TITLE
Reconcile divergent branches

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git config pull.rebase true
           git fetch --all
           git checkout -b release-dev origin/release-dev
           mkdir ${{ matrix.version }}
@@ -77,6 +78,7 @@ jobs:
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git config pull.rebase true
           git fetch --all
           git checkout -b release-dev origin/release-dev
           mkdir ${{ matrix.version }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ armv7, aarch64, s390x, ppc64le, x86 ]
+        arch: [ armv7, aarch64, s390x, ppc64le, amd64 ]
         version: [ 0.9.3, 0.10.0, 0.11.0, 0.12.0, 0.13.0, 0.14.0, 0.14.1, 0.14.2, 0.15.0, 0.16.0, 0.17.0, 0.18.0, 0.18.1 ]
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ armv7, aarch64, s390x, ppc64le, x86 ]
+        arch: [ armv7, aarch64, s390x, ppc64le, amd64 ]
         version: [ 0.6.0, 0.6.1, 0.7.0, 0.8.0, 0.9.0, 0.9.1, 0.9.2 ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When pushing the compiled binaries to remote, diverging branches can occur. These need to be resolved.